### PR TITLE
Fallback WebSerial Support and launcher URL detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ To use this system, you need:
 
 - A **Celio-Device** (hardware dongle)
 - A **Game Boy Advance link cable**
-- A Chromium-based browser (WebUSB required)
+- A browser with WebUSB (Chromium-based — Chrome/Edge) or WebSerial (Firefox 151+)
 
 The web client is available at:  
 https://celi0.link  
 
-> ⚠ Firefox is not supported because it does not support the WebUSB API.
+> ℹ Chromium browsers use WebUSB. Firefox 151+ is supported via WebSerial (the
+> connect button falls back to "Connect Serial" automatically when WebUSB is unavailable).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/router": "^20.1.0",
         "@tailwindcss/postcss": "^4.1.12",
         "@tailwindcss/vite": "^4.1.12",
+        "@types/w3c-web-serial": "^1.0.7",
         "@types/w3c-web-usb": "^1.0.10",
         "rxjs": "~7.8.0",
         "socket.io-client": "^4.8.1",
@@ -3629,6 +3630,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
@@ -3864,6 +3919,12 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/w3c-web-serial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
+      "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
+      "license": "MIT"
     },
     "node_modules/@types/w3c-web-usb": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@tailwindcss/vite": "^4.1.12",
     "@types/w3c-web-usb": "^1.0.10",
+    "@types/w3c-web-serial": "^1.0.7",
     "rxjs": "~7.8.0",
     "socket.io-client": "^4.8.1",
     "true-myth": "^9.1.0",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,10 +14,11 @@ export const routes: Routes = [
       { path: '', redirectTo: 'onlineLink', pathMatch: 'full' },
       { path: 'onlineLink', component: OnlineLinkComponent,
         data: { linkMode: Mode.onlineLink, readyInstruction: "Link Mode is now ready! If you haven't already, connect the <br> Link-Cable to your Gameboy Advance and talk to the Pokémon Center clerk." } },
+      // No awVariant in the route data: the page asks the user to pick
+      // Advance Wars 1 or 2 before connecting, which also sets the
+      // ready-screen copy.
       { path: 'advanceWarsLink', component: OnlineLinkComponent,
-        data: { linkMode: Mode.advanceWars, awVariant: 1, readyInstruction: "Link Mode is now ready! Connect the Link Cable to both Game Boy Advances <br> and start a VS battle from the Advance Wars menu." } },
-      { path: 'advanceWars2Link', component: OnlineLinkComponent,
-        data: { linkMode: Mode.advanceWars, awVariant: 2, readyInstruction: "Link Mode is now ready! Connect the Link Cable to both Game Boy Advances <br> and start a VS battle from the Advance Wars 2 menu." } },
+        data: { linkMode: Mode.advanceWars } },
       { path: 'tradeEmu', component: TradeEmuComponent },
       { path: 'emulatorLink', component: EmulatorLinkComponent },
       { path: 'emulatorOnlineLink', component: EmulatorOnlineLinkComponent }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { OnlineLinkComponent } from '../pages/onlineLink/onlineLink.component';
 import { TradeEmuComponent } from '../pages/tradeEmu/tradeEmu.component';
 import { EmulatorLinkComponent } from '../pages/emulatorLink/emulatorLink.component';
 import {EmulatorOnlineLinkComponent} from '../pages/emulatorOnlineLink/emulatorOnlineLink.component';
+import { Mode } from '../shared/linkExchange/common';
 
 export const routes: Routes = [
   {
@@ -11,7 +12,12 @@ export const routes: Routes = [
     component: LayoutComponent, // persistent sidebar
     children: [
       { path: '', redirectTo: 'onlineLink', pathMatch: 'full' },
-      { path: 'onlineLink', component: OnlineLinkComponent },
+      { path: 'onlineLink', component: OnlineLinkComponent,
+        data: { linkMode: Mode.onlineLink, readyInstruction: "Link Mode is now ready! If you haven't already, connect the <br> Link-Cable to your Gameboy Advance and talk to the Pokémon Center clerk." } },
+      { path: 'advanceWarsLink', component: OnlineLinkComponent,
+        data: { linkMode: Mode.advanceWars, awVariant: 1, readyInstruction: "Link Mode is now ready! Connect the Link Cable to both Game Boy Advances <br> and start a VS battle from the Advance Wars menu." } },
+      { path: 'advanceWars2Link', component: OnlineLinkComponent,
+        data: { linkMode: Mode.advanceWars, awVariant: 2, readyInstruction: "Link Mode is now ready! Connect the Link Cable to both Game Boy Advances <br> and start a VS battle from the Advance Wars 2 menu." } },
       { path: 'tradeEmu', component: TradeEmuComponent },
       { path: 'emulatorLink', component: EmulatorLinkComponent },
       { path: 'emulatorOnlineLink', component: EmulatorOnlineLinkComponent }

--- a/src/layout/sidebar.component.html
+++ b/src/layout/sidebar.component.html
@@ -18,38 +18,6 @@
         </span>
       </li>
       <li class="flex-1">
-        <a routerLink="/advanceWarsLink" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
-          Advance Wars Link
-        </a>
-        <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
-          <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link Advance Wars online using a physical Gameboy Advance">
-            <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
-                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>
-                <path d="m12,17v-5.5c0-.276-.224-.5-.5-.5h-1.5" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
-                <circle cx="12" cy="7.25" r="1.25" fill="currentColor" stroke-width="2"></circle>
-              </g>
-            </svg>
-          </div>
-        </span>
-      </li>
-      <li class="flex-1">
-        <a routerLink="/advanceWars2Link" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
-          Advance Wars 2 Link
-        </a>
-        <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
-          <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link Advance Wars 2 online using a physical Gameboy Advance">
-            <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
-                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>
-                <path d="m12,17v-5.5c0-.276-.224-.5-.5-.5h-1.5" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
-                <circle cx="12" cy="7.25" r="1.25" fill="currentColor" stroke-width="2"></circle>
-              </g>
-            </svg>
-          </div>
-        </span>
-      </li>
-      <li class="flex-1">
         <a routerLink="/emulatorOnlineLink" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
           Online Emulator Link
         </a>
@@ -87,6 +55,24 @@
         </a>
         <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
           <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Simulate a trade with a physical Gameboy Advance. Supports .ek3 and .pk3 files">
+            <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
+                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>
+                <path d="m12,17v-5.5c0-.276-.224-.5-.5-.5h-1.5" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
+                <circle cx="12" cy="7.25" r="1.25" fill="currentColor" stroke-width="2"></circle>
+              </g>
+            </svg>
+          </div>
+        </span>
+      </li>
+      <!-- Empty slot: keeps Advance Wars visually separated from the link modes above -->
+      <li class="flex-1"></li>
+      <li class="flex-1">
+        <a routerLink="/advanceWarsLink" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
+          Advance Wars
+        </a>
+        <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
+          <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link Advance Wars 1 or 2 online using a physical Gameboy Advance">
             <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
               <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
                 <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>

--- a/src/layout/sidebar.component.html
+++ b/src/layout/sidebar.component.html
@@ -1,12 +1,44 @@
 <div class="h-screen w-67 bg-[#8890f8] flex flex-col">
   <div class="flex-1">
-    <ul class="menu flex-col h-[22em] w-[19em]">
+    <ul class="menu flex-col h-[27em] w-[19em]">
       <li class="flex-1">
         <a routerLink="/onlineLink" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
           Online Link
         </a>
         <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
           <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link online using a physical Gameboy Advance">
+            <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
+                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>
+                <path d="m12,17v-5.5c0-.276-.224-.5-.5-.5h-1.5" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
+                <circle cx="12" cy="7.25" r="1.25" fill="currentColor" stroke-width="2"></circle>
+              </g>
+            </svg>
+          </div>
+        </span>
+      </li>
+      <li class="flex-1">
+        <a routerLink="/advanceWarsLink" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
+          Advance Wars Link
+        </a>
+        <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
+          <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link Advance Wars online using a physical Gameboy Advance">
+            <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
+                <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>
+                <path d="m12,17v-5.5c0-.276-.224-.5-.5-.5h-1.5" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></path>
+                <circle cx="12" cy="7.25" r="1.25" fill="currentColor" stroke-width="2"></circle>
+              </g>
+            </svg>
+          </div>
+        </span>
+      </li>
+      <li class="flex-1">
+        <a routerLink="/advanceWars2Link" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
+          Advance Wars 2 Link
+        </a>
+        <span class="absolute top-1.5 right-0.5  px-2 py-0.5 rounded-full">
+          <div class="tooltip before:text-2xl tooltip-bottom font-Gen3" data-tip="Link Advance Wars 2 online using a physical Gameboy Advance">
             <svg class="size-[1.4em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
               <g fill="currentColor" stroke-linejoin="miter" stroke-linecap="butt">
                 <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-linecap="square" stroke-miterlimit="10" stroke-width="2"></circle>

--- a/src/layout/sidebar.component.html
+++ b/src/layout/sidebar.component.html
@@ -67,7 +67,14 @@
       </li>
     </ul>
   </div>
-  <ul class="menu flex-col h-[11.5em] w-[19em]">
+  <ul class="menu flex-col w-[19em] {{ fromLauncher ? 'h-[17.25em]' : 'h-[11.5em]' }}">
+    @if (fromLauncher) {
+    <li class="flex-1">
+      <a [href]="launcherUrl" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]">
+        Return to Launcher
+      </a>
+    </li>
+    }
     <li class="flex-1">
       <a href="https://gblink.io/" target="_blank" class="box-menu w-full font-Gen3 text-2xl menu-item-unselected bg-[#FFFFFF]" routerLinkActive="menu-item" [routerLinkActiveOptions]="{ exact: true }">
         Get Hardware

--- a/src/layout/sidebar.component.ts
+++ b/src/layout/sidebar.component.ts
@@ -2,10 +2,32 @@ import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import {NgOptimizedImage} from '@angular/common';
 
+// Whether this client was opened from the GB Link launcher (?from=gblink-launcher).
+// Captured at module load — before Angular's router runs its initial navigation,
+// which strips the query param from the URL. We also remember it in sessionStorage
+// so the state survives page reloads (the URL no longer carries ?from by then).
+// sessionStorage is per-tab and clears when the tab closes, so a fresh tab opened
+// straight to Celio won't show the button.
+const FROM_LAUNCHER = (() => {
+  const KEY = 'gblink-from-launcher';
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get('from') === 'gblink-launcher';
+    if (fromUrl) sessionStorage.setItem(KEY, '1');
+    return fromUrl || sessionStorage.getItem(KEY) === '1';
+  } catch {
+    return new URLSearchParams(window.location.search).get('from') === 'gblink-launcher';
+  }
+})();
+
 @Component({
   selector: 'app-sidebar',
   standalone: true,
   imports: [RouterLink, RouterLinkActive],
   templateUrl: './sidebar.component.html'
 })
-export class SidebarComponent {}
+export class SidebarComponent {
+  // When this client was opened from the GB Link launcher (?from=gblink-launcher),
+  // show a "Return to Launcher" sidebar item so users can hop back to it.
+  protected readonly launcherUrl = 'https://launcher.gblink.io';
+  protected readonly fromLauncher = FROM_LAUNCHER;
+}

--- a/src/pages/emulatorLink/emulatorLink.component.html
+++ b/src/pages/emulatorLink/emulatorLink.component.html
@@ -13,16 +13,17 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
-        <button (click)="connect()" class="btn btn-lg">Connect Celio Device</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
+        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
+        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
       </div>
       <div *ngIf="hasReached(StepsState.ChooseEmulator)" class="font-Gen3 text-4xl">
-        Celio USB connection status: <br>
+        Celio connection status: <br>
         Ready!
       </div>
       <div *ngIf="webUsbError" class="font-Gen3 text-4xl">
-        Web USB is not supported by this browser.<br>
-        Please use Chrome or another Chromium based browser.
+        Neither WebUSB nor WebSerial is supported by this browser.<br>
+        Use Chrome/Edge (WebUSB or WebSerial) or Firefox 151+ (WebSerial).
       </div>
     </div>
     <img *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" src="assets/down_arrow.png" class="animate-bob absolute bottom-3 right-2 w-6 h-6 image-pixelated" />

--- a/src/pages/emulatorLink/emulatorLink.component.html
+++ b/src/pages/emulatorLink/emulatorLink.component.html
@@ -1,6 +1,6 @@
 <div class="flex w-full flex-col">
   <ul class="steps w-full">
-    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Celio Device</li>
+    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Device</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 1 }">Choose Emulator</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 2 }">Load Script</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 3 }">Wait for Server</li>

--- a/src/pages/emulatorLink/emulatorLink.component.html
+++ b/src/pages/emulatorLink/emulatorLink.component.html
@@ -13,9 +13,11 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
-        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
-        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
+        <div class="flex gap-2">
+          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
+          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+        </div>
       </div>
       <div *ngIf="hasReached(StepsState.ChooseEmulator)" class="font-Gen3 text-4xl">
         Celio connection status: <br>

--- a/src/pages/emulatorLink/emulatorLink.component.html
+++ b/src/pages/emulatorLink/emulatorLink.component.html
@@ -15,8 +15,7 @@
     <div class="flex w-full h-[5rem]">
       <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
         <div class="flex gap-2">
-          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
-          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+          <button *ngIf="connectTransport" (click)="connect(connectTransport)" class="btn">{{ connectLabel }}</button>
         </div>
       </div>
       <div *ngIf="hasReached(StepsState.ChooseEmulator)" class="font-Gen3 text-4xl">

--- a/src/pages/emulatorLink/emulatorLink.component.ts
+++ b/src/pages/emulatorLink/emulatorLink.component.ts
@@ -91,13 +91,13 @@ export class EmulatorLinkComponent extends CelioPageAbstract<StepsState>{
     this.linkSession?.destroy();
   }
 
-  connect(): void {
-    if (navigator.usb == undefined) {
+  connect(kind: 'usb' | 'serial' = 'usb'): void {
+    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
       this.webUsbError = true;
       return;
     }
 
-    this.linkDeviceService.connectDevice()
+    this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {
         this.linkDeviceConnected = isConnected
         if (isConnected) {

--- a/src/pages/emulatorLink/emulatorLink.component.ts
+++ b/src/pages/emulatorLink/emulatorLink.component.ts
@@ -92,10 +92,7 @@ export class EmulatorLinkComponent extends CelioPageAbstract<StepsState>{
   }
 
   connect(kind: 'usb' | 'serial' = 'usb'): void {
-    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
-      this.webUsbError = true;
-      return;
-    }
+    if (kind === 'usb' ? !this.usbSupported : !this.serialSupported) return;
 
     this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -100,10 +100,7 @@
         <img src="assets/GBA.png" class="image-pixelated h-48 w-auto relative mr-[8rem]"/>
       </div>
 
-      <div class="box mt-12 font-Gen3 text-4xl">
-        Link Mode is now ready! If you haven't already, connect the <br>
-        Link-Cable to your Gameboy Advance and talk to the Pokémon Center clerk.
-      </div>
+      <div class="box mt-12 font-Gen3 text-4xl" [innerHTML]="readyInstruction"></div>
     </div>
   </div>
 </div>

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -1,4 +1,22 @@
-<div class="flex w-full flex-col">
+<div *ngIf="awVariantNeeded" class="flex w-full flex-col">
+  <div class="font-Gen3 text-4xl">Select your game</div>
+
+  <div class="divider"></div>
+
+  <div class="box relative">
+    <div class="flex w-full h-[8rem]">
+      <div class="card rounded-box grid grow place-items-center">
+        <button (click)="selectAwVariant(1)" class="btn btn-lg">Advance Wars</button>
+      </div>
+      <div class="divider divider-horizontal"><div class="font-Gen3 text-4xl">OR</div></div>
+      <div class="card rounded-box grid grow place-items-center">
+        <button (click)="selectAwVariant(2)" class="btn btn-lg">Advance Wars 2</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div *ngIf="!awVariantNeeded" class="flex w-full flex-col">
   <ul class="steps w-full">
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Celio Device</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 1 }">Join Session</li>
@@ -25,6 +43,9 @@
         Use Chrome/Edge (WebUSB or WebSerial) or Firefox 151+ (WebSerial).
       </div>
     </div>
+    <button *ngIf="isAwMode && isCurrentlyIn(StepsState.ConnectingCelioDevice)" (click)="resetAwVariant()" class="btn btn-sm text-2xl absolute top-3 right-2">
+      {{ awVariant === 2 ? 'Advance Wars 2' : 'Advance Wars' }} — Change Game
+    </button>
     <img *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" src="assets/down_arrow.png" class="animate-bob absolute bottom-3 right-2 w-6 h-6 image-pixelated" />
   </div>
 

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -18,7 +18,7 @@
 
 <div *ngIf="!awVariantNeeded" class="flex w-full flex-col">
   <ul class="steps w-full">
-    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Celio Device</li>
+    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Device</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 1 }">Join Session</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 2 }">Wait for Partner</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 3 }">Start Link Mode</li>

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -11,16 +11,17 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
-        <button (click)="connect()" class="btn btn-lg">Connect Celio Device</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
+        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
+        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
       </div>
       <div *ngIf="hasReached(StepsState.JoiningSession)" class="font-Gen3 text-4xl">
-        Celio USB connection status: <br>
+        Celio connection status: <br>
         Ready!
       </div>
       <div *ngIf="webUsbError" class="font-Gen3 text-4xl">
-        Web USB is not supported by this browser.<br>
-        Please use Chrome or another Chromium based browser.
+        Neither WebUSB nor WebSerial is supported by this browser.<br>
+        Use Chrome/Edge (WebUSB or WebSerial) or Firefox 151+ (WebSerial).
       </div>
     </div>
     <img *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" src="assets/down_arrow.png" class="animate-bob absolute bottom-3 right-2 w-6 h-6 image-pixelated" />

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -11,9 +11,11 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
-        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
-        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
+        <div class="flex gap-2">
+          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
+          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+        </div>
       </div>
       <div *ngIf="hasReached(StepsState.JoiningSession)" class="font-Gen3 text-4xl">
         Celio connection status: <br>

--- a/src/pages/onlineLink/onlineLink.component.html
+++ b/src/pages/onlineLink/onlineLink.component.html
@@ -13,8 +13,7 @@
     <div class="flex w-full h-[5rem]">
       <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
         <div class="flex gap-2">
-          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
-          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+          <button *ngIf="connectTransport" (click)="connect(connectTransport)" class="btn">{{ connectLabel }}</button>
         </div>
       </div>
       <div *ngIf="hasReached(StepsState.JoiningSession)" class="font-Gen3 text-4xl">

--- a/src/pages/onlineLink/onlineLink.component.ts
+++ b/src/pages/onlineLink/onlineLink.component.ts
@@ -93,10 +93,7 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
   }
 
   connect(kind: 'usb' | 'serial' = 'usb'): void {
-    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
-      this.webUsbError = true;
-      return;
-    }
+    if (kind === 'usb' ? !this.usbSupported : !this.serialSupported) return;
 
     this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {

--- a/src/pages/onlineLink/onlineLink.component.ts
+++ b/src/pages/onlineLink/onlineLink.component.ts
@@ -1,7 +1,8 @@
 import {ChangeDetectorRef, Component, inject, ViewChild} from '@angular/core';
 import { NgClass, NgIf } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 
-import {CommandType} from '../../shared/linkExchange/common';
+import {CommandType, Mode} from '../../shared/linkExchange/common';
 
 import {Subscription, take} from 'rxjs';
 import {PlayerSessionService} from '../../services/playersession.service';
@@ -38,6 +39,12 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
   @ViewChild(ToastComponent) toast!: ToastComponent;
 
   private linkDeviceService = inject(LinkDeviceService)
+  private route = inject(ActivatedRoute)
+
+  // Per-route (app.routes.ts): which firmware mode this page drives and the matching ready-screen copy.
+  protected linkMode: Mode = this.route.snapshot.data['linkMode'] ?? Mode.onlineLink;
+  protected awVariant: number | undefined = this.route.snapshot.data['awVariant'];
+  protected readyInstruction: string = this.route.snapshot.data['readyInstruction'] ?? '';
 
   protected sessionId: string | undefined = "";
 
@@ -105,7 +112,7 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
   }
 
   start() {
-    LinkDeviceUtils.tryEnableLinkMode(new StatusEmitterLinkDevice(this.linkDeviceService))
+    LinkDeviceUtils.tryEnableLinkMode(new StatusEmitterLinkDevice(this.linkDeviceService), this.linkMode, this.awVariant)
       .then(() => {
         this.advanceLinkState(StepsState.Ready);
       })

--- a/src/pages/onlineLink/onlineLink.component.ts
+++ b/src/pages/onlineLink/onlineLink.component.ts
@@ -46,6 +46,26 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
   protected awVariant: number | undefined = this.route.snapshot.data['awVariant'];
   protected readyInstruction: string = this.route.snapshot.data['readyInstruction'] ?? '';
 
+  protected get isAwMode(): boolean {
+    return this.linkMode === Mode.advanceWars;
+  }
+
+  // Advance Wars covers two games with different link protocols; the page
+  // blocks until the user picks one so the right variant reaches the firmware.
+  protected get awVariantNeeded(): boolean {
+    return this.isAwMode && this.awVariant === undefined;
+  }
+
+  protected selectAwVariant(variant: number) {
+    this.awVariant = variant;
+    this.readyInstruction = "Link Mode is now ready! Connect the Link Cable to both Game Boy Advances <br> and start a VS battle from the "
+      + (variant === 2 ? "Advance Wars 2" : "Advance Wars") + " menu.";
+  }
+
+  protected resetAwVariant() {
+    this.awVariant = undefined;
+  }
+
   protected sessionId: string | undefined = "";
 
   protected StepsState = StepsState;

--- a/src/pages/onlineLink/onlineLink.component.ts
+++ b/src/pages/onlineLink/onlineLink.component.ts
@@ -105,8 +105,9 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
     });
   }
 
-  ngOnInit() {
+  async ngOnInit() {
     if (this.linkDeviceService.isConnected()) {
+      if (!await this.checkAwFirmware()) return;
       this.advanceLinkState(StepsState.JoiningSession);
     }
   }
@@ -123,12 +124,37 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
     if (kind === 'usb' ? !this.usbSupported : !this.serialSupported) return;
 
     this.linkDeviceService.connectDevice(kind)
-      .then(isConnected => {
+      .then(async isConnected => {
         if (isConnected) {
+          if (!await this.checkAwFirmware()) return;
           this.advanceLinkState(StepsState.JoiningSession);
         }
       }
     )
+  }
+
+  // The Advance Wars protocol proxy shipped in firmware 2.2.0; the relay in
+  // older builds can't link over the internet, so block AW sessions early
+  // instead of failing mid-handshake. Other modes work on older firmware.
+  private static readonly awMinFirmware = { major: 2, minor: 2, patch: 0 };
+
+  private async checkAwFirmware(): Promise<boolean> {
+    if (!this.isAwMode) return true;
+
+    const min = OnlineLinkComponent.awMinFirmware;
+    const version = await this.linkDeviceService.getFirmwareVersion();
+    const ok = version !== undefined && (
+      version.major !== min.major ? version.major > min.major :
+      version.minor !== min.minor ? version.minor > min.minor :
+      version.patch >= min.patch);
+    if (ok) return true;
+
+    const have = version ? `v${version.major}.${version.minor}.${version.patch}` : 'an unknown version';
+    this.toast?.show(
+      `Advance Wars needs firmware v${min.major}.${min.minor}.${min.patch} or newer — this adapter is running ${have}. Update it from the GBLink launcher and reconnect.`,
+      'error', 8000);
+    await this.linkDeviceService.disconnect();
+    return false;
   }
 
   start() {

--- a/src/pages/onlineLink/onlineLink.component.ts
+++ b/src/pages/onlineLink/onlineLink.component.ts
@@ -92,13 +92,13 @@ export class OnlineLinkComponent extends CelioPageAbstract<StepsState>{
     this.linkSession?.destroy();
   }
 
-  connect(): void {
-    if (navigator.usb == undefined) {
+  connect(kind: 'usb' | 'serial' = 'usb'): void {
+    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
       this.webUsbError = true;
       return;
     }
 
-    this.linkDeviceService.connectDevice()
+    this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {
         if (isConnected) {
           this.advanceLinkState(StepsState.JoiningSession);

--- a/src/pages/shared/celioPage.abstact.ts
+++ b/src/pages/shared/celioPage.abstact.ts
@@ -14,6 +14,16 @@ export class CelioPageAbstract<StateEnumT> {
     return !this.usbSupported && !this.serialSupported;
   }
 
+  // Prefer WebUSB; fall back to WebSerial only when WebUSB is unavailable
+  // (e.g. Firefox 151+, or Chromium with WebUSB disabled).
+  protected get connectTransport(): 'usb' | 'serial' | null {
+    return this.usbSupported ? 'usb' : (this.serialSupported ? 'serial' : null);
+  }
+
+  protected get connectLabel(): string {
+    return this.connectTransport === 'serial' ? 'Connect Serial' : 'Connect USB';
+  }
+
   constructor(private cd: ChangeDetectorRef) {
     // @ts-ignore
     this.stepState = 0;

--- a/src/pages/shared/celioPage.abstact.ts
+++ b/src/pages/shared/celioPage.abstact.ts
@@ -5,7 +5,14 @@ import {environment} from '../../environments/environment';
 export class CelioPageAbstract<StateEnumT> {
 
   protected stepState: StateEnumT;
-  protected webUsbError: boolean = false;
+  protected readonly usbSupported: boolean =
+    typeof navigator !== 'undefined' && navigator.usb !== undefined;
+  protected readonly serialSupported: boolean =
+    typeof navigator !== 'undefined' && navigator.serial !== undefined;
+
+  protected get webUsbError(): boolean {
+    return !this.usbSupported && !this.serialSupported;
+  }
 
   constructor(private cd: ChangeDetectorRef) {
     // @ts-ignore

--- a/src/pages/tradeEmu/tradeEmu.component.html
+++ b/src/pages/tradeEmu/tradeEmu.component.html
@@ -12,8 +12,7 @@
     <div class="flex w-full h-[5rem]">
       <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
         <div class="flex gap-2">
-          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
-          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+          <button *ngIf="connectTransport" (click)="connect(connectTransport)" class="btn">{{ connectLabel }}</button>
         </div>
       </div>
       <div *ngIf="hasReached(StepsState.SelectingPokemon)" class="font-Gen3 text-4xl">

--- a/src/pages/tradeEmu/tradeEmu.component.html
+++ b/src/pages/tradeEmu/tradeEmu.component.html
@@ -10,16 +10,17 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
-        <button (click)="connect()" class="btn btn-lg">Connect Celio Device</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
+        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
+        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
       </div>
       <div *ngIf="hasReached(StepsState.SelectingPokemon)" class="font-Gen3 text-4xl">
         Celio connection status: <br>
         Ready!
       </div>
       <div *ngIf="webUsbError" class="font-Gen3 text-4xl">
-        Web USB is not supported by this browser.<br>
-        Please use Chrome or another Chromium based browser.
+        Neither WebUSB nor WebSerial is supported by this browser.<br>
+        Use Chrome/Edge (WebUSB or WebSerial) or Firefox 151+ (WebSerial).
       </div>
     </div>
     <img *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" src="assets/down_arrow.png" class="animate-bob absolute bottom-3 right-2 w-6 h-6 image-pixelated" />

--- a/src/pages/tradeEmu/tradeEmu.component.html
+++ b/src/pages/tradeEmu/tradeEmu.component.html
@@ -1,6 +1,6 @@
 <div class="flex w-full flex-col">
   <ul class="steps w-full">
-    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Celio Device</li>
+    <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 0 }">Connect Device</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 1 }">Selecting Pokémon</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 2 }">Uploading Pokémon</li>
     <li class="step font-Gen3 text-2xl" [ngClass]="{ 'step-primary': stepState >= 3 }">Ready</li>

--- a/src/pages/tradeEmu/tradeEmu.component.html
+++ b/src/pages/tradeEmu/tradeEmu.component.html
@@ -10,9 +10,11 @@
 
   <div class="box relative">
     <div class="flex w-full h-[5rem]">
-      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center gap-2">
-        <button (click)="connect('usb')" class="btn btn-lg">Connect Celio Device (USB)</button>
-        <button (click)="connect('serial')" class="btn btn-lg">Connect Celio Device (Serial)</button>
+      <div *ngIf="isCurrentlyIn(StepsState.ConnectingCelioDevice)" class="card rounded-box grid grow place-items-center">
+        <div class="flex gap-2">
+          <button (click)="connect('usb')" [disabled]="!usbSupported" class="btn">Connect USB</button>
+          <button (click)="connect('serial')" [disabled]="!serialSupported" class="btn">Connect Serial</button>
+        </div>
       </div>
       <div *ngIf="hasReached(StepsState.SelectingPokemon)" class="font-Gen3 text-4xl">
         Celio connection status: <br>

--- a/src/pages/tradeEmu/tradeEmu.component.ts
+++ b/src/pages/tradeEmu/tradeEmu.component.ts
@@ -65,10 +65,7 @@ export class TradeEmuComponent extends CelioPageAbstract<StepsState>{
   }
 
   connect(kind: 'usb' | 'serial' = 'usb'): void {
-    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
-      this.webUsbError = true;
-      return;
-    }
+    if (kind === 'usb' ? !this.usbSupported : !this.serialSupported) return;
 
     this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {

--- a/src/pages/tradeEmu/tradeEmu.component.ts
+++ b/src/pages/tradeEmu/tradeEmu.component.ts
@@ -64,13 +64,13 @@ export class TradeEmuComponent extends CelioPageAbstract<StepsState>{
     this.statusSubscription.unsubscribe();
   }
 
-  connect(): void {
-    if (navigator.usb == undefined) {
+  connect(kind: 'usb' | 'serial' = 'usb'): void {
+    if (kind === 'usb' ? navigator.usb == undefined : navigator.serial == undefined) {
       this.webUsbError = true;
       return;
     }
 
-    this.linkDeviceService.connectDevice()
+    this.linkDeviceService.connectDevice(kind)
       .then(isConnected => {
           this.linkDeviceConnected = isConnected
           if (isConnected) {

--- a/src/services/linkdevice.service.ts
+++ b/src/services/linkdevice.service.ts
@@ -2,9 +2,27 @@ import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import {CommandType, DataArray, LinkStatus} from '../shared/linkExchange/common';
 
+type Mode = 'usb' | 'serial';
+
+// SerialLayer frame format (GBLink firmware):
+//   | 0x47 0x42 | channel:1 | len:2 LE | payload[len] |
+//     sync 'GB'   0=cmd,1=data,2=status
+const SYNC_0 = 0x47;
+const SYNC_1 = 0x42;
+const CH_CMD = 0x00;
+const CH_DATA = 0x01;
+const CH_STATUS = 0x02;
+const MAX_PAYLOAD = 64;
+
+type RxState = 'sync1' | 'sync2' | 'channel' | 'lenLo' | 'lenHi' | 'payload';
+
 @Injectable({  providedIn: 'root' })
 export class LinkDeviceService {
   private device: USBDevice | undefined = undefined;
+  private port: SerialPort | undefined = undefined;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | undefined = undefined;
+  private writer: WritableStreamDefaultWriter<Uint8Array> | undefined = undefined;
+  private mode: Mode | undefined = undefined;
 
   readonly statusEndpoint: number = 1
   readonly dataEndpoint: number = 2
@@ -16,6 +34,9 @@ export class LinkDeviceService {
       { vendorId: 0x8086, productId: 0xf8a1 },
     ],
   };
+  readonly serialOptions: SerialPortRequestOptions = {
+    filters: [{ usbVendorId: 0x2fe3 }],
+  };
 
   private statusEventSubject = new Subject<LinkStatus>();
   public statusEvents$ = this.statusEventSubject.asObservable();
@@ -26,30 +47,46 @@ export class LinkDeviceService {
   private disconnectEventSubject = new Subject<void>();
   public disconnectEvents$ = this.disconnectEventSubject.asObservable();
 
+  // Framing parser state (serial only).
+  private rxState: RxState = 'sync1';
+  private rxChannel: number = 0;
+  private rxLen: number = 0;
+  private rxBuf: Uint8Array | null = null;
+  private rxPos: number = 0;
+
   constructor() {
-    if (navigator.usb != undefined)
+    if (typeof navigator !== 'undefined' && navigator.usb != undefined)
     {
       navigator.usb.ondisconnect = event => {
-        console.log("USB device disconnected:", event.device);
-        this.device = undefined;
-        this.disconnectEventSubject.next()
+        if (this.mode === 'usb') {
+          console.log("USB device disconnected:", event.device);
+          this.device = undefined;
+          this.mode = undefined;
+          this.disconnectEventSubject.next()
+        }
       };
     }
   }
 
-  isConnected(): boolean { return this.device != undefined; }
+  isConnected(): boolean {
+    return this.mode === 'usb' ? this.device != undefined : this.port != undefined;
+  }
 
-  async connectDevice(): Promise<boolean> {
+  async connectDevice(kind: Mode = 'usb'): Promise<boolean> {
+    if (kind === 'serial') return this.connectSerial();
+    return this.connectUsb();
+  }
 
+  private async connectUsb(): Promise<boolean> {
     try {
       this.device = await navigator.usb.requestDevice(this.options);
-
       if (!this.device) return false;
 
       await this.device.open();
       await this.device.selectConfiguration(1);
       await this.device.claimInterface(0);
 
+      this.mode = 'usb';
       this.readStatus();
       this.readData();
 
@@ -60,29 +97,144 @@ export class LinkDeviceService {
     }
   }
 
-  readData() {
+  private async connectSerial(): Promise<boolean> {
+    try {
+      this.port = await navigator.serial.requestPort(this.serialOptions);
+      await this.port.open({ baudRate: 115200 });
+      this.writer = this.port.writable!.getWriter();
+      this.reader = this.port.readable!.getReader();
+
+      this.mode = 'serial';
+      this.rxState = 'sync1';
+      this.runSerialReadLoop();
+      return true;
+    } catch (err) {
+      console.log('Serial connection to Celio Device failed', err);
+      this.port = undefined;
+      this.reader = undefined;
+      this.writer = undefined;
+      return false;
+    }
+  }
+
+  private async runSerialReadLoop() {
+    try {
+      while (this.reader) {
+        const { value, done } = await this.reader.read();
+        if (done) break;
+        if (!value || value.length === 0) continue;
+        for (let i = 0; i < value.length; i++) this.feedByte(value[i]);
+      }
+    } catch (e) {
+      console.log('Serial read loop error:', e);
+    } finally {
+      if (this.mode === 'serial') {
+        this.port = undefined;
+        this.reader = undefined;
+        this.writer = undefined;
+        this.mode = undefined;
+        this.disconnectEventSubject.next();
+      }
+    }
+  }
+
+  private feedByte(b: number) {
+    switch (this.rxState) {
+      case 'sync1':
+        if (b === SYNC_0) this.rxState = 'sync2';
+        break;
+      case 'sync2':
+        if (b === SYNC_1) this.rxState = 'channel';
+        else if (b === SYNC_0) this.rxState = 'sync2';
+        else this.rxState = 'sync1';
+        break;
+      case 'channel':
+        this.rxChannel = b;
+        this.rxState = 'lenLo';
+        break;
+      case 'lenLo':
+        this.rxLen = b;
+        this.rxState = 'lenHi';
+        break;
+      case 'lenHi':
+        this.rxLen |= b << 8;
+        if (this.rxLen > MAX_PAYLOAD) { this.rxState = 'sync1'; break; }
+        this.rxPos = 0;
+        this.rxBuf = new Uint8Array(this.rxLen);
+        if (this.rxLen === 0) {
+          this.dispatchFrame();
+          this.rxState = 'sync1';
+        } else {
+          this.rxState = 'payload';
+        }
+        break;
+      case 'payload':
+        this.rxBuf![this.rxPos++] = b;
+        if (this.rxPos >= this.rxLen) {
+          this.dispatchFrame();
+          this.rxState = 'sync1';
+        }
+        break;
+    }
+  }
+
+  private dispatchFrame() {
+    if (!this.rxBuf) return;
+    if (this.rxChannel === CH_DATA && this.rxBuf.byteLength === 64) {
+      const uint16Array = new Uint16Array(this.rxBuf.buffer, this.rxBuf.byteOffset, 32);
+      const dataArray = Array.from(uint16Array) as DataArray;
+      this.dataEventSubject.next(dataArray);
+    } else if (this.rxChannel === CH_STATUS && this.rxBuf.byteLength === 2) {
+      const status = new Uint16Array(this.rxBuf.buffer, this.rxBuf.byteOffset, 1);
+      this.statusEventSubject.next(status[0] as LinkStatus);
+    }
+  }
+
+  private async writeFrame(channel: number, payload: Uint8Array): Promise<boolean> {
+    if (!this.writer) return false;
+    if (payload.length > MAX_PAYLOAD) return false;
+    const frame = new Uint8Array(5 + payload.length);
+    frame[0] = SYNC_0;
+    frame[1] = SYNC_1;
+    frame[2] = channel;
+    frame[3] = payload.length & 0xFF;
+    frame[4] = (payload.length >> 8) & 0xFF;
+    frame.set(payload, 5);
+    try {
+      await this.writer.write(frame);
+      return true;
+    } catch (e) {
+      console.error('Serial write failed:', e);
+      return false;
+    }
+  }
+
+  private readData() {
     this.device!.transferIn(this.dataEndpoint, this.endPointBufferSize).then((result: USBInTransferResult) => {
       if (result.data && result.data.byteLength == 64) {
         const uint16Array = new Uint16Array(result.data.buffer, result.data.byteOffset, 32);
         const dataArray = Array.from(uint16Array) as DataArray;
         this.dataEventSubject.next(dataArray);
       }
-      this.readData()
+      if (this.mode === 'usb') this.readData()
     }, (err: Error) => {console.log(err)})
   }
 
-  readStatus() {
+  private readStatus() {
     this.device!.transferIn(this.statusEndpoint, this.endPointBufferSize).then((result: USBInTransferResult) => {
       if (result.data?.byteLength == 2) {
         const status = new Uint16Array(result.data.buffer);
         this.statusEventSubject.next(status[0] as LinkStatus)
-        this.readStatus()
+        if (this.mode === 'usb') this.readStatus()
       }
     }, (err: Error) => {console.log(err)})
   }
 
   sendData(data: DataArray) : Promise<boolean> {
     const uint16Array = new Uint16Array(data);
+    if (this.mode === 'serial') {
+      return this.writeFrame(CH_DATA, new Uint8Array(uint16Array.buffer));
+    }
     return this.device!.transferOut(this.dataEndpoint, uint16Array).then(
       (result: USBOutTransferResult) => {return true },
       (err: Error) => {console.log(err); return false;})
@@ -90,8 +242,11 @@ export class LinkDeviceService {
 
   async sendDataRaw(data: Uint8Array): Promise<boolean> {
     if (data.length > 64) return false;
+    if (this.mode === 'serial') {
+      return this.writeFrame(CH_DATA, data);
+    }
     try {
-      const result: USBOutTransferResult = await this.device!.transferOut(this.dataEndpoint, data);
+      await this.device!.transferOut(this.dataEndpoint, data);
       return true;
     } catch (error) {
       console.error("Error when sending raw data to device: " + JSON.stringify(error));
@@ -103,12 +258,14 @@ export class LinkDeviceService {
     let message: Uint8Array<ArrayBuffer> = new Uint8Array(1 + args.length);
     message[0] = command;
     message.set(args, 1)
+    if (this.mode === 'serial') {
+      return this.writeFrame(CH_CMD, message);
+    }
     try {
       const result: USBOutTransferResult = await this.device!.transferOut(this.statusEndpoint, message);
       if (result.status != "ok") {
         console.log("Send Command to device result :" + JSON.stringify(result));
       }
-
       return true;
     } catch (error) {
       console.error(error);
@@ -116,7 +273,20 @@ export class LinkDeviceService {
     }
   }
 
-  disconnect() {
-    this.device!.close();
+  async disconnect() {
+    if (this.mode === 'serial') {
+      try { if (this.reader) await this.reader.cancel(); } catch (_) {}
+      try { this.reader?.releaseLock(); } catch (_) {}
+      try { this.writer?.releaseLock(); } catch (_) {}
+      try { await this.port?.close(); } catch (_) {}
+      this.reader = undefined;
+      this.writer = undefined;
+      this.port = undefined;
+      this.mode = undefined;
+    } else if (this.mode === 'usb') {
+      this.device!.close();
+      this.device = undefined;
+      this.mode = undefined;
+    }
   }
 }

--- a/src/services/linkdevice.service.ts
+++ b/src/services/linkdevice.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
-import {CommandType, DataArray, LinkStatus} from '../shared/linkExchange/common';
+import {CommandType, DataArray, FirmwareVersion, LinkStatus} from '../shared/linkExchange/common';
 
 type Mode = 'usb' | 'serial';
 
@@ -43,6 +43,11 @@ export class LinkDeviceService {
 
   private dataEventSubject = new Subject<DataArray>();
   public dataEvents$ = this.dataEventSubject.asObservable();
+
+  // Data-channel payloads that aren't 64-byte link packets — command replies
+  // like GetFirmwareInfo (5 bytes: [0x0F, major, minor, patch, flags]).
+  private dataRawEventSubject = new Subject<Uint8Array>();
+  public dataRawEvents$ = this.dataRawEventSubject.asObservable();
 
   private disconnectEventSubject = new Subject<void>();
   public disconnectEvents$ = this.disconnectEventSubject.asObservable();
@@ -184,6 +189,8 @@ export class LinkDeviceService {
       const uint16Array = new Uint16Array(this.rxBuf.buffer, this.rxBuf.byteOffset, 32);
       const dataArray = Array.from(uint16Array) as DataArray;
       this.dataEventSubject.next(dataArray);
+    } else if (this.rxChannel === CH_DATA && this.rxBuf.byteLength > 0) {
+      this.dataRawEventSubject.next(this.rxBuf);
     } else if (this.rxChannel === CH_STATUS && this.rxBuf.byteLength === 2) {
       const status = new Uint16Array(this.rxBuf.buffer, this.rxBuf.byteOffset, 1);
       this.statusEventSubject.next(status[0] as LinkStatus);
@@ -215,6 +222,8 @@ export class LinkDeviceService {
         const uint16Array = new Uint16Array(result.data.buffer, result.data.byteOffset, 32);
         const dataArray = Array.from(uint16Array) as DataArray;
         this.dataEventSubject.next(dataArray);
+      } else if (result.data && result.data.byteLength > 0) {
+        this.dataRawEventSubject.next(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength));
       }
       if (this.mode === 'usb') this.readData()
     }, (err: Error) => {console.log(err)})
@@ -271,6 +280,32 @@ export class LinkDeviceService {
       console.error(error);
       return false;
     }
+  }
+
+  // Query the firmware version (GetFirmwareInfo, 0x0F). The reply arrives on
+  // the data channel, so subscribe before sending. Resolves undefined on
+  // timeout — firmware too old to answer, or no device.
+  getFirmwareVersion(timeoutMs: number = 1500): Promise<FirmwareVersion | undefined> {
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        subscription.unsubscribe();
+        resolve(undefined);
+      }, timeoutMs);
+      const subscription = this.dataRawEvents$.subscribe(bytes => {
+        if (bytes.length >= 4 && bytes[0] === CommandType.GetFirmwareInfo) {
+          clearTimeout(timer);
+          subscription.unsubscribe();
+          resolve({ major: bytes[1], minor: bytes[2], patch: bytes[3] });
+        }
+      });
+      this.sendCommand(CommandType.GetFirmwareInfo).then(sent => {
+        if (!sent) {
+          clearTimeout(timer);
+          subscription.unsubscribe();
+          resolve(undefined);
+        }
+      });
+    });
   }
 
   async disconnect() {

--- a/src/shared/linkDeviceUtils.ts
+++ b/src/shared/linkDeviceUtils.ts
@@ -14,9 +14,12 @@ export class LinkDeviceUtils {
     });
   }
 
-  private static enableLinkMode(statusEmitter: StatusEmitterAbstract):Promise<void> {
-    let args: Uint8Array = new Uint8Array(1);
-    args[0] = Mode.onlineLink;
+  private static enableLinkMode(statusEmitter: StatusEmitterAbstract, mode: Mode = Mode.onlineLink, variant?: number):Promise<void> {
+    let args: Uint8Array = new Uint8Array(variant === undefined ? 1 : 2);
+    args[0] = mode;
+    if (variant !== undefined) {
+      args[1] = variant;
+    }
     return new Promise<void>((resolve, reject) => {
       statusEmitter.receiveCommand(CommandType.SetMode, args).then(ok => {
         if (!ok) {
@@ -49,13 +52,13 @@ export class LinkDeviceUtils {
     });
   }
 
-  static async tryEnableLinkMode(statusEmitter: StatusEmitterAbstract) {
+  static async tryEnableLinkMode(statusEmitter: StatusEmitterAbstract, mode: Mode = Mode.onlineLink, variant?: number) {
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
     const waitForReady = this.createReadyPromise(statusEmitter);
 
     await this.sendCancel(statusEmitter);
     await delay(500);
-    await this.enableLinkMode(statusEmitter);
+    await this.enableLinkMode(statusEmitter, mode, variant);
     await waitForReady;
   }
 }

--- a/src/shared/linkExchange/common.ts
+++ b/src/shared/linkExchange/common.ts
@@ -25,12 +25,19 @@ export enum LinkStatus {
 export enum CommandType {
   SetMode = 0x00,
   Cancel = 0x01,
+  GetFirmwareInfo = 0x0F,
   SetModeMaster = 0x10,
   SetModeSlave = 0x11,
   StartHandshake= 0x12,
   ConnectLink = 0x13,
 
   EmuSessionStart = 0xFF0A
+}
+
+export interface FirmwareVersion {
+  major: number;
+  minor: number;
+  patch: number;
 }
 
 export enum Mode {

--- a/src/shared/linkExchange/common.ts
+++ b/src/shared/linkExchange/common.ts
@@ -35,7 +35,8 @@ export enum CommandType {
 
 export enum Mode {
   tradeEmu = 0x00,
-  onlineLink = 0x01
+  onlineLink = 0x01,
+  advanceWars = 0x04
 }
 
 export interface CommandPacket {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": ["w3c-web-usb"]
+    "types": ["w3c-web-usb", "w3c-web-serial"]
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "target": "ES2022",
     "module": "preserve",
     "typeRoots": ["node_modules/@types"],
-    "types": ["w3c-web-usb"]
+    "types": ["w3c-web-usb", "w3c-web-serial"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
Support WebSerial as  fallback if WebUSB is not supported or not enabled. Notably this allows the use of Firefox Desktop 151+. WebSerial requires firmware version v2.1.1 or higher.

Launcher URL detection:
On a normal page load there is no UI change.
If /?from=gblink-launcher is detected in the initial URL a return to launcher button is displayed with matching styling in the menu.

Update readme with webserial support information.